### PR TITLE
Fixes control text for distance field.

### DIFF
--- a/demo/graphicscontroller.cpp
+++ b/demo/graphicscontroller.cpp
@@ -160,7 +160,7 @@ void GraphicsController::paintEvent(QPaintEvent *event)
 		drawControlText(painter,5,"[c]", "Hide Controls");
         drawControlText(painter,25,"[i]", "Add Vertex");
         drawControlText(painter,45,"[d]", "Delete Vertex");
-        drawControlText(painter,65,"[i]", "Generate distance field");
+        drawControlText(painter,65,"[g]", "Generate distance field");
         drawControlText(painter,85,"[s]", "Open Settings");
 	}
 	else


### PR DESCRIPTION
The control text for generate-distance-field action displays the wrong key.